### PR TITLE
jaraco.itertools 6.4.3 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 06c8727afcad659e29ce78773870428500f4daf6f13b9c2f5154ddb21cbca90d
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<39]
 


### PR DESCRIPTION
jaraco.itertools 6.4.3 rebuild

**Destination channel:** Defaults

### Links

- [PKG-10895]
- dev_url:        https://github.com/jaraco/jaraco.itertools/tree/v6.4.3
- conda_forge:    https://github.com/conda-forge/jaraco.itertools-feedstock
- pypi:           https://pypi.org/project/jaraco.itertools/6.4.3
- pypi inspector: https://inspector.pypi.io/project/jaraco.itertools/6.4.3

### Explanation of changes:

- missing py3.14 for OSX, for some reason other platforms has versions 3.14 but not OSX


[PKG-10895]: https://anaconda.atlassian.net/browse/PKG-10895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ